### PR TITLE
Cleanup of deprecated code and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ Outputs addition information to the console.
 
 ## Change log
 
-#### 0009 - FoundryVTT v11 compatibility
+#### 0011 - FoundryVTT v11 compatibility (addendum)
+Another slight technical patch. Removes some deprecated API usage, which was causing unnecessary compatibility warnings in the browser log.
+Otherwise, the outdated (and now fixed) code would become incompatible with future Foundry versions 12 and higher.
+
+#### 0010 - FoundryVTT v11 compatibility
 Mainly declarational changes in module.json, and some cosmetics.
 Also slightly harmonized version numbering: It now reads "0009" across the whole mod.
 Semantic versioning in upcoming releases recommended!

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "always-centred",
   "title": "Always Centred",
   "description": "Always Centred is a module that automatically centres the camera on the players' tokens and zooms to fit them in.",
-  "version": "0010",
+  "version": "0011",
   "authors": [{"name": "SDoehren"}],
   "esmodules": ["src/always-centred.js"],
   "compatibility": {

--- a/src/always-centred.js
+++ b/src/always-centred.js
@@ -52,7 +52,7 @@ Hooks.on("ready", () => {
         ui.notifications.info("Always Centred | The DM has control of the player screen centring.");
     }
 
-    if (game.settings.get("always-centred", "LatestVersion")!==game.modules.get("always-centred").data.version && game.user.isGM){
+    if (game.settings.get("always-centred", "LatestVersion")!==game.modules.get("always-centred").version && game.user.isGM){
         let message = "This module is now compatible with Foundry VTT v11. <br/>" +
             "Nothing has changed in a functional way. Find below the original note for the most recent update (prior to v11 migration):<br/><br/>" +
             "Hi,<br/>Thanks for installing/updating Always Centred" +
@@ -62,7 +62,7 @@ Hooks.on("ready", () => {
             "<br/>This message will not be shown again until the next update.<br/><br/>" +
             "All the best,<br/>SDoehren<br/>Discord Server: https://discord.gg/QNQZwGGxuN";
         ChatMessage.create({whisper:ChatMessage.getWhisperRecipients("GM"),content: message,speaker:ChatMessage.getSpeaker({alias: "Always Centred"})}, {});
-        game.settings.set("always-centred", "LatestVersion",game.modules.get("always-centred").data.version)
+        game.settings.set("always-centred", "LatestVersion",game.modules.get("always-centred").version)
     }
 
 });


### PR DESCRIPTION
Gets rid of log warnings, plus fixes a version number in Readme.

The eliminated log warning is this:
![image](https://github.com/SDoehren/always-centred/assets/39616483/a3619789-3adf-40b6-978f-0540666aae75)

... caused by these little goblins in the code:
![image](https://github.com/SDoehren/always-centred/assets/39616483/3c9da6e0-846c-4688-b4c4-17b49b32d8ac)

